### PR TITLE
Fix compatibility issues due to ModsConfig.IsActive

### DIFF
--- a/Source/VSEWW/VSEWW/Startup.cs
+++ b/Source/VSEWW/VSEWW/Startup.cs
@@ -40,8 +40,8 @@ namespace VSEWW
             // Cache field info
             weatherDecider_ticksWhenRainAllowedAgain = typeof(WeatherDecider).GetField("ticksWhenRainAllowedAgain", BindingFlags.NonPublic | BindingFlags.Instance);
             // Mod active check
-            CEActive = ModsConfig.IsActive("CETeam.CombatExtended");
-            NoPauseChallengeActive = ModsConfig.IsActive("brrainz.nopausechallenge");
+            CEActive = ModsConfig.IsActive("CETeam.CombatExtended") || ModsConfig.IsActive("CETeam.CombatExtended_steam");
+            NoPauseChallengeActive = ModsConfig.IsActive("brrainz.nopausechallenge") || ModsConfig.IsActive("brrainz.nopausechallenge_steam");
             // Create color
             counterColor = new Color
             {


### PR DESCRIPTION
The issue occurs when checking if a mod is active with `ModsConfig.IsActive` when running the workshop version of a mod while there's a local copy in the mods directory. In those cases the `ModsConfig.IsActive` will return false as the running mod will have the `_steam` postfix.

The simple fix is to simply check for mod ID, as well as the mod ID with the `_steam` postfix.

For related PRs, check:
Vanilla-Expanded/VanillaExpandedFramework#72